### PR TITLE
fix: _WELL_KNOWN → _WELL_KNOWN_PATHS typo in dashboard onboarding (restores CI)

### DIFF
--- a/brain_mcp/dashboard/routes/onboarding.py
+++ b/brain_mcp/dashboard/routes/onboarding.py
@@ -144,11 +144,11 @@ _WELL_KNOWN_PATHS = [
 # Add Claude Desktop with platform-aware path
 try:
     from brain_mcp.platform import claude_desktop_conversations
-    _WELL_KNOWN.append(
+    _WELL_KNOWN_PATHS.append(
         ("claude-desktop", "Claude Desktop", claude_desktop_conversations(), "*.jsonl")
     )
 except Exception:
-    _WELL_KNOWN.append(
+    _WELL_KNOWN_PATHS.append(
         ("claude-desktop", "Claude Desktop", Path.home() / "Library" / "Application Support" / "Claude" / "chat_conversations", "*.jsonl")
     )
 


### PR DESCRIPTION
## Summary

One-word typo fix. `brain_mcp/dashboard/routes/onboarding.py` at lines 147 and 151 references `_WELL_KNOWN` which is undefined; the variable is declared on line 139 and consumed on line 236 as `_WELL_KNOWN_PATHS`.

The bug raises `NameError` at module-import time for every test client that imports the dashboard app, cascading into **97 ERRORs across `test_dashboard*.py`** — broken since around commit `d7e8a68` (2026-03-21).

## Why this matters

This is the last blocker before tagging v0.4.0 (SHELET reference implementation) for PyPI publish. With this fix merged:
- CI should return green for the first time since v0.3.1
- Tag `v0.4.0` can move to this merge commit and trigger the OIDC-based PyPI publish workflow cleanly

## Diff

```diff
-    _WELL_KNOWN.append(
+    _WELL_KNOWN_PATHS.append(
```
(2 occurrences)

## Test plan

- [ ] CI `pytest tests/` goes from "97 dashboard ERRORs" to all green
- [ ] `python -c 'from brain_mcp.dashboard.routes import onboarding'` imports without NameError (verified locally ✓)
- [ ] All 4 references to `_WELL_KNOWN_PATHS` in the file are consistent (verified locally ✓ — lines 139, 147, 151, 236)

🤖 Generated with [Claude Code](https://claude.com/claude-code)